### PR TITLE
feat: add query func

### DIFF
--- a/lib/swagger/fetch.js
+++ b/lib/swagger/fetch.js
@@ -24,7 +24,6 @@ class FetchClient {
     let method = opts.method
     delete opts.method;
 
-    opts.query = {};
     opts.headers = {}
     opts.query['pretty'] = true
     opts.headers['Authorization'] = `bearer ${token}`
@@ -57,10 +56,12 @@ class FetchClient {
    * @param {boolean} options.stream - true if called by a "stream method".
    */
   http(options) {
-    const body = JSON.stringify(options.body)
+    const body = JSON.stringify(options.body);
+    const query = options.query || {};
 
     return this._fetch(new URL(this.url + options.pathname).href, {
       body,
+      query,
       method: options.method
     })
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fib-k8s-client",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Simplified Kubernetes client for FIBJS.",
   "main": "./lib/index.js",
   "repository": "git://github.com/fibjs/fib-k8s-client.git",


### PR DESCRIPTION
add query function,
reference to  [Label selectors with API](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api)
you can  get specific node via labelSelector like this:
```
client.api.v1.nodes.get({
    query: {
        labelSelector: "kubernetes.io/hostname=master"
    }
}
```
some of  query params
 - `pretty `
 - `labelSelector`
 - `fieldSelector `
 - `limit `
 - `resourceVersion `
 - `timeoutSeconds `
 - `watch `
 - ...
you can find p these params at [kubernetes-api-doc](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/)